### PR TITLE
Remove deprecated `disableJsonSupport` property in `MySQL`/`MariaDB`.

### DIFF
--- a/src/db/mysql/ColumnSchema.php
+++ b/src/db/mysql/ColumnSchema.php
@@ -19,17 +19,6 @@ use yii\db\JsonExpression;
 class ColumnSchema extends \yii\db\ColumnSchema
 {
     /**
-     * @var bool whether the column schema should OMIT using JSON support feature.
-     * You can use this property to make upgrade to Yii 2.0.14 easier.
-     * Default to `false`, meaning JSON support is enabled.
-     *
-     * @since 2.0.14.1
-     * @deprecated Since 2.0.14.1 and will be removed in 2.1.
-     */
-    public $disableJsonSupport = false;
-
-
-    /**
      * {@inheritdoc}
      */
     public function dbTypecast($value)
@@ -42,7 +31,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
             return $value;
         }
 
-        if (!$this->disableJsonSupport && $this->dbType === Schema::TYPE_JSON) {
+        if ($this->dbType === Schema::TYPE_JSON) {
             return new JsonExpression($value, $this->type);
         }
 
@@ -58,7 +47,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
             return null;
         }
 
-        if (!$this->disableJsonSupport && $this->type === Schema::TYPE_JSON) {
+        if ($this->type === Schema::TYPE_JSON) {
             return json_decode($value, true);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
