### PR TITLE
Remove deprecated properties `disableJsonSupport`, `disableArraySupport`, `deserializeArrayColumnToArrayExpression` in ColumnSchema in `PgSQL`.

### DIFF
--- a/src/db/pgsql/ColumnSchema.php
+++ b/src/db/pgsql/ColumnSchema.php
@@ -23,33 +23,6 @@ class ColumnSchema extends \yii\db\ColumnSchema
      */
     public $dimension = 0;
     /**
-     * @var bool whether the column schema should OMIT using JSON support feature.
-     * You can use this property to make upgrade to Yii 2.0.14 easier.
-     * Default to `false`, meaning JSON support is enabled.
-     *
-     * @since 2.0.14.1
-     * @deprecated Since 2.0.14.1 and will be removed in 2.1.
-     */
-    public $disableJsonSupport = false;
-    /**
-     * @var bool whether the column schema should OMIT using PgSQL Arrays support feature.
-     * You can use this property to make upgrade to Yii 2.0.14 easier.
-     * Default to `false`, meaning Arrays support is enabled.
-     *
-     * @since 2.0.14.1
-     * @deprecated Since 2.0.14.1 and will be removed in 2.1.
-     */
-    public $disableArraySupport = false;
-    /**
-     * @var bool whether the Array column value should be unserialized to an [[ArrayExpression]] object.
-     * You can use this property to make upgrade to Yii 2.0.14 easier.
-     * Default to `true`, meaning arrays are unserialized to [[ArrayExpression]] objects.
-     *
-     * @since 2.0.14.1
-     * @deprecated Since 2.0.14.1 and will be removed in 2.1.
-     */
-    public $deserializeArrayColumnToArrayExpression = true;
-    /**
      * @var string name of associated sequence if column is auto-incremental
      * @since 2.0.29
      */
@@ -70,11 +43,10 @@ class ColumnSchema extends \yii\db\ColumnSchema
         }
 
         if ($this->dimension > 0) {
-            return $this->disableArraySupport
-                ? (string) $value
-                : new ArrayExpression($value, $this->dbType, $this->dimension);
+            return new ArrayExpression($value, $this->dbType, $this->dimension);
         }
-        if (!$this->disableJsonSupport && in_array($this->dbType, [Schema::TYPE_JSON, Schema::TYPE_JSONB], true)) {
+
+        if (in_array($this->dbType, [Schema::TYPE_JSON, Schema::TYPE_JSONB], true)) {
             return new JsonExpression($value, $this->dbType);
         }
 
@@ -87,12 +59,10 @@ class ColumnSchema extends \yii\db\ColumnSchema
     public function phpTypecast($value)
     {
         if ($this->dimension > 0) {
-            if ($this->disableArraySupport) {
-                return $value;
-            }
             if (!is_array($value)) {
                 $value = $this->getArrayParser()->parse($value);
             }
+
             if (is_array($value)) {
                 array_walk_recursive($value, function (&$val, $key) {
                     $val = $this->phpTypecastValue($val);
@@ -101,9 +71,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
                 return null;
             }
 
-            return $this->deserializeArrayColumnToArrayExpression
-                ? new ArrayExpression($value, $this->dbType, $this->dimension)
-                : $value;
+            return $value;
         }
 
         return $this->phpTypecastValue($value);
@@ -133,7 +101,7 @@ class ColumnSchema extends \yii\db\ColumnSchema
                 }
                 return (bool) $value;
             case Schema::TYPE_JSON:
-                return $this->disableJsonSupport ? $value : json_decode($value, true);
+                return json_decode($value, true);
         }
 
         return parent::phpTypecast($value);

--- a/tests/framework/db/pgsql/ActiveRecordTest.php
+++ b/tests/framework/db/pgsql/ActiveRecordTest.php
@@ -183,22 +183,31 @@ class ActiveRecordTest extends \yiiunit\framework\db\ActiveRecordTest
     public function testArrayValues($attributes)
     {
         $type = new ArrayAndJsonTypes();
+
         foreach ($attributes as $attribute => $expected) {
             $type->$attribute = $expected[0];
         }
+
         $type->save();
 
         $type = ArrayAndJsonTypes::find()->one();
+
         foreach ($attributes as $attribute => $expected) {
             $expected = isset($expected[1]) ? $expected[1] : $expected[0];
             $value = $type->$attribute;
+
+            if ($expected instanceof ArrayExpression) {
+                $expected = $expected->getValue();
+            }
 
             $this->assertEquals($expected, $value, 'In column ' . $attribute);
 
             if ($value instanceof ArrayExpression) {
                 $this->assertInstanceOf('\ArrayAccess', $value);
                 $this->assertInstanceOf('\Traversable', $value);
-                foreach ($type->$attribute as $key => $v) { // testing arrayaccess
+
+                foreach ($type->$attribute as $key => $v) {
+                    // testing arrayaccess
                     $this->assertSame($expected[$key], $value[$key]);
                 }
             }
@@ -208,6 +217,7 @@ class ActiveRecordTest extends \yiiunit\framework\db\ActiveRecordTest
         foreach ($attributes as $attribute => $expected) {
             $type->markAttributeDirty($attribute);
         }
+
         $this->assertSame(1, $type->update(), 'The record got updated');
     }
 

--- a/tests/framework/db/pgsql/SchemaTest.php
+++ b/tests/framework/db/pgsql/SchemaTest.php
@@ -358,12 +358,12 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
 
         $schema = $connection->schema->getTableSchema('schema2.custom_type_test_table');
         $model = EnumTypeInCustomSchema::find()->one();
-        $this->assertSame(['VAL2'], $model->test_type->getValue());
+        $this->assertSame(['VAL2'], $model->test_type);
 
         $model->test_type = ['VAL1'];
         $model->save();
 
         $modelAfterUpdate = EnumTypeInCustomSchema::find()->one();
-        $this->assertSame(['VAL1'], $modelAfterUpdate->test_type->getValue());
+        $this->assertSame(['VAL1'], $modelAfterUpdate->test_type);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
