### PR TITLE
Remove deprecated `className()` method in `BaseObject.php`.

### DIFF
--- a/src/base/BaseObject.php
+++ b/src/base/BaseObject.php
@@ -78,12 +78,12 @@ class BaseObject implements Configurable
 {
     /**
      * Returns the fully qualified name of this class.
+     *
      * @return string the fully qualified name of this class.
-     * @deprecated since 2.0.14. On PHP >=5.5, use `::class` instead.
      */
-    public static function className()
+    public static function className(): string
     {
-        return get_called_class();
+        return static::class;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
