### PR TITLE
Remove deprecated `getHasChanged()` method in `Dependency.php`.

### DIFF
--- a/src/caching/Dependency.php
+++ b/src/caching/Dependency.php
@@ -58,17 +58,6 @@ abstract class Dependency extends \yii\base\BaseObject
     }
 
     /**
-     * Returns a value indicating whether the dependency has changed.
-     * @deprecated since version 2.0.11. Will be removed in version 2.1. Use [[isChanged()]] instead.
-     * @param CacheInterface $cache the cache component that is currently evaluating this dependency
-     * @return bool whether the dependency has changed.
-     */
-    public function getHasChanged($cache)
-    {
-        return $this->isChanged($cache);
-    }
-
-    /**
      * Checks whether the dependency is changed.
      * @param CacheInterface $cache the cache component that is currently evaluating this dependency
      * @return bool whether the dependency has changed.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
