### PR TITLE
Remove deprecated `comboNotUnique` property in `UniqueValidator.php`.

### DIFF
--- a/src/validators/UniqueValidator.php
+++ b/src/validators/UniqueValidator.php
@@ -78,13 +78,6 @@ class UniqueValidator extends Validator
      */
     public $message;
     /**
-     * @var string
-     * @since 2.0.9
-     * @deprecated since version 2.0.10, to be removed in 2.1. Use [[message]] property
-     * to setup custom message for multiple target attributes.
-     */
-    public $comboNotUnique;
-    /**
      * @var string and|or define how target attributes are related
      * @since 2.0.11
      */
@@ -106,11 +99,8 @@ class UniqueValidator extends Validator
             return;
         }
         if (is_array($this->targetAttribute) && count($this->targetAttribute) > 1) {
-            // fallback for deprecated `comboNotUnique` property - use it as message if is set
-            if ($this->comboNotUnique === null) {
+            if ($this->message === null) {
                 $this->message = Yii::t('yii', 'The combination {values} of {attributes} has already been taken.');
-            } else {
-                $this->message = $this->comboNotUnique;
             }
         } else {
             $this->message = Yii::t('yii', '{attribute} "{value}" has already been taken.');

--- a/tests/framework/validators/UniqueValidatorTest.php
+++ b/tests/framework/validators/UniqueValidatorTest.php
@@ -61,16 +61,6 @@ abstract class UniqueValidatorTest extends DatabaseTestCase
         $validator->validateAttribute($model, 'order_id');
         $this->assertTrue($model->hasErrors('order_id'));
         $this->assertEquals($customError, $model->getFirstError('order_id'));
-
-        // fallback for deprecated `comboNotUnique` - should be removed on 2.1.0
-        $validator = new UniqueValidator([
-            'targetAttribute' => ['order_id', 'item_id'],
-            'comboNotUnique' => 'Custom message for {attributes} with values {values}',
-        ]);
-        $model->clearErrors();
-        $validator->validateAttribute($model, 'order_id');
-        $this->assertTrue($model->hasErrors('order_id'));
-        $this->assertEquals($customError, $model->getFirstError('order_id'));
     }
 
     public function testValidateInvalidAttribute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
