### PR TITLE
Refactor `Connection::class` to remove unnecessary code in `getQuoter()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Yii Core version 2 Change Log
 - Bug #59: Update Oracle column `Schema::class` to handle binary data conversion (@terabytesoftw)
 - Bug #61: Add `Quoter::class` for `PostgreSQL`, `Oracle`, `SQLite`, `MSSQL`, and `MySQL` (@terabytesoftw)
 - Bug #62: Refactor tearDown method in session classes for clean table `session` (@terabytesoftw)
+- Bug #63: Refactor `Connection::class` to remove unnecessary code in `getQuoter()` method (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/Connection.php
+++ b/src/db/Connection.php
@@ -923,7 +923,6 @@ class Connection extends Component
             if (isset($this->quoterMap[$driver])) {
                 $config = !is_array($this->quoterMap[$driver])
                     ? ['class' => $this->quoterMap[$driver]] : $this->quoterMap[$driver];
-                $config['db'] = $this;
 
                 $this->_quoter = Yii::createObject(
                     $config,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
