### PR TITLE
Remove unnecessary method `newBuildOrderByAndLimit()` in `QueryBuilder::class` for `MSSQL`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Yii Core version 2 Change Log
 - Bug #65: Update Oracle `ColumnSchema::class` to handle binary data conversion (@terabytesoftw)
 - Bug #68: Fix `Boolean` type for `MSSQL 2008`, `MSSQL 2012`, `MSSQL 2014`, `MSSQL 2016` (@terabytesoftw)
 - Bug #69: Refactor `insert()`, `insertWithReturningPk()` and `upsert()` in `MSSQL`, `MYSQL`, `OCI`, `PGSQL` and `SQLITE` (@terabytesoftw)
+- Bug #71: Remove unnecessary method `newBuildOrderByAndLimit()` in `QueryBuilder::class` for `MSSQL` (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/mssql/QueryBuilder.php
+++ b/src/db/mssql/QueryBuilder.php
@@ -42,7 +42,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
         Schema::TYPE_MONEY => 'decimal(19,4)',
     ];
 
-
     /**
      * {@inheritdoc}
      */
@@ -63,32 +62,11 @@ class QueryBuilder extends \yii\db\QueryBuilder
         ExpressionInterface|int|null $limit,
         ExpressionInterface|int|null $offset,
     ): string {
+        $orderBy = $this->buildOrderBy($orderBy);
+
         if (!$this->hasOffset($offset) && !$this->hasLimit($limit)) {
-            $orderBy = $this->buildOrderBy($orderBy);
             return $orderBy === '' ? $sql : $sql . $this->separator . $orderBy;
         }
-
-        return $this->newBuildOrderByAndLimit($sql, $orderBy, $limit, $offset);
-    }
-
-    /**
-     * Builds the ORDER BY/LIMIT/OFFSET clauses for SQL SERVER 2012 or newer.
-     *
-     * @param string $sql the existing SQL (without ORDER BY/LIMIT/OFFSET)
-     * @param array|null $orderBy the order by columns. See [[\yii\db\Query::orderBy]] for more details on how to
-     * specify this parameter.
-     * @param int|null|ExpressionInterface $limit the limit number. See [[\yii\db\Query::limit]] for more details.
-     * @param int|null|ExpressionInterface $offset the offset number. See [[\yii\db\Query::offset]] for more details.
-     *
-     * @return string the SQL completed with ORDER BY/LIMIT/OFFSET (if any).
-     */
-    protected function newBuildOrderByAndLimit(
-        string $sql,
-        array|null $orderBy,
-        ExpressionInterface|int|null $limit,
-        ExpressionInterface|int|null $offset,
-    ): string {
-        $orderBy = $this->buildOrderBy($orderBy);
 
         if ($orderBy === '') {
             // ORDER BY clause is required when FETCH and OFFSET are in the SQL.
@@ -102,7 +80,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
          */
         $offsetString = $this->hasOffset($offset) ?
             ($offset instanceof ExpressionInterface ? $this->buildExpression($offset) : (string)$offset) : '0';
-
 
         $sql .= $this->separator . 'OFFSET ' . $offsetString . ' ROWS';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
