### PR TITLE
Remove `Oracle-11c` service image versions in build workflow.

### DIFF
--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -61,8 +61,8 @@ jobs:
           --name=oci
           --health-cmd healthcheck.sh
           --health-interval 15s
-          --health-timeout 10s
-          --health-retries 15
+          --health-timeout 15s
+          --health-retries 20
 
     steps:
       - name: Checkout.

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -60,9 +60,10 @@ jobs:
         options: >-
           --name=oci
           --health-cmd healthcheck.sh
-          --health-interval 15s
-          --health-timeout 15s
-          --health-retries 20
+          --health-interval 30s
+          --health-timeout 20s
+          --health-retries 30
+          --health-start-period 120s
 
     steps:
       - name: Checkout.

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php }}-oracle-${{ matrix.oracle }}
+    name: PHP ${{ matrix.php }}-oracle-${{ matrix.oracle.version }}
 
     env:
       EXTENSIONS: oci8, pdo, pdo_oci
@@ -43,13 +43,16 @@ jobs:
           - 8.1
 
         oracle:
-          - konnecteam/docker-oracle-12c
-          - gvenzl/oracle-xe:18
-          - gvenzl/oracle-xe:21
+          - version: 12c
+            image: konnecteam/docker-oracle-12c:sequelize
+          - version: 18
+            image: gvenzl/oracle-xe:18
+          - version: 21
+            image: gvenzl/oracle-xe:21
 
     services:
       oci:
-        image: ${{ matrix.oracle }}
+        image: ${{ matrix.oracle.image }}
         ports:
           - 1521:1521
         env:

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -44,7 +44,7 @@ jobs:
 
         oracle:
           - version: 12c
-            image: konnecteam/docker-oracle-12c:sequelize
+            image: tqldtqmapirails/oracle-xe-12c:latest
           - version: 18
             image: gvenzl/oracle-xe:18
           - version: 21
@@ -60,9 +60,9 @@ jobs:
         options: >-
           --name=oci
           --health-cmd healthcheck.sh
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 15
 
     steps:
       - name: Checkout.

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -43,8 +43,6 @@ jobs:
           - 8.1
 
         oracle:
-          - version: 12c
-            image: tqldtqmapirails/oracle-xe-12c:latest
           - version: 18
             image: gvenzl/oracle-xe:18
           - version: 21
@@ -60,10 +58,9 @@ jobs:
         options: >-
           --name=oci
           --health-cmd healthcheck.sh
-          --health-interval 30s
-          --health-timeout 20s
-          --health-retries 30
-          --health-start-period 120s
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Checkout.

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -43,13 +43,13 @@ jobs:
           - 8.1
 
         oracle:
-          - 11
-          - 18
-          - 21
+          - tqldtqmapirails/oracle-xe-12c:latest
+          - gvenzl/oracle-xe:18
+          - gvenzl/oracle-xe:21
 
     services:
       oci:
-        image: gvenzl/oracle-xe:${{ matrix.oracle }}
+        image: ${{ matrix.oracle }}
         ports:
           - 1521:1521
         env:

--- a/.github/workflows/build-oracle.yml
+++ b/.github/workflows/build-oracle.yml
@@ -43,7 +43,7 @@ jobs:
           - 8.1
 
         oracle:
-          - tqldtqmapirails/oracle-xe-12c:latest
+          - konnecteam/docker-oracle-12c
           - gvenzl/oracle-xe:18
           - gvenzl/oracle-xe:21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Yii Core version 2 Change Log
 - Bug #75: Refactor `prepareInsertValues()` method in `QueryBuilder::class` to accept `TableSchema` object (@terabytesoftw)
 - Bug #77: Add support for test `Oracle` 18, 21 (@terabytesoftw)
 - Bug #78: Fix test case for `getSchemaNames()` method in `SchemaTest::class` in `Oracle` (@terabytesoftw)
-- Enh #83: Update `Oracle-12c` service image versions in build workflow (@terabytesoftw)
+- Enh #83: Remove `Oracle-11c` service image versions in build workflow (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Yii Core version 2 Change Log
 - Bug #75: Refactor `prepareInsertValues()` method in `QueryBuilder::class` to accept `TableSchema` object (@terabytesoftw)
 - Bug #77: Add support for test `Oracle` 18, 21 (@terabytesoftw)
 - Bug #78: Fix test case for `getSchemaNames()` method in `SchemaTest::class` in `Oracle` (@terabytesoftw)
+- Enh #83: Update `Oracle-12c` service image versions in build workflow (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
