### PR TITLE
Remove unnecesary `resolveTableNames()` and refactor `resolveTableName()` in `Schema::class` in `MSSQL`, `MYSQL`, `OCI`, `PGSQL`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Yii Core version 2 Change Log
 - Bug #75: Refactor `prepareInsertValues()` method in `QueryBuilder::class` to accept `TableSchema` object (@terabytesoftw)
 - Bug #77: Add support for test `Oracle` 18, 21 (@terabytesoftw)
 - Bug #78: Fix test case for `getSchemaNames()` method in `SchemaTest::class` in `Oracle` (@terabytesoftw)
-- Enh #83: Remove `Oracle-11c` service image versions in build workflow (@terabytesoftw)
+- Enh #84: Remove `Oracle-11c` service image versions in build workflow (@terabytesoftw)
+- Enh #86: Remove unnecesary `resolveTableNames()` and refactor `resolveTableName()` in `Schema::class` in `MSSQL`, `MYSQL`, `OCI`, `PGSQL` (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/Schema.php
+++ b/src/db/Schema.php
@@ -123,15 +123,16 @@ abstract class Schema extends BaseObject
      */
     private $_serverVersion;
 
-
     /**
      * Resolves the table name and schema name (if any).
-     * @param string $name the table name
+     *
+     * @param string $name the table name. The table name may contain schema name if any. Do not quote the table name.
+     *
      * @return TableSchema [[TableSchema]] with resolved table, schema, etc. names.
+     *
      * @throws NotSupportedException if this method is not supported by the DBMS.
-     * @since 2.0.13
      */
-    protected function resolveTableName($name)
+    protected function resolveTableName(string $name): TableSchema
     {
         throw new NotSupportedException(get_class($this) . ' does not support resolving table names.');
     }
@@ -164,10 +165,12 @@ abstract class Schema extends BaseObject
 
     /**
      * Loads the metadata for the specified table.
-     * @param string $name table name
+     *
+     * @param string $table table name.
+     *
      * @return TableSchema|null DBMS-dependent table metadata, `null` if the table does not exist.
      */
-    abstract protected function loadTableSchema($name);
+    abstract protected function loadTableSchema(string $table): TableSchema|null;
 
     /**
      * Creates a column schema for the database.

--- a/src/db/TableSchema.php
+++ b/src/db/TableSchema.php
@@ -1,9 +1,6 @@
 <?php
-/**
- * @link https://www.yiiframework.com/
- * @copyright Copyright (c) 2008 Yii Software LLC
- * @license https://www.yiiframework.com/license/
- */
+
+declare(strict_types=1);
 
 namespace yii\db;
 
@@ -14,34 +11,33 @@ use yii\base\InvalidArgumentException;
  * TableSchema represents the metadata of a database table.
  *
  * @property-read array $columnNames List of column names.
- *
- * @author Qiang Xue <qiang.xue@gmail.com>
- * @since 2.0
  */
 class TableSchema extends BaseObject
 {
     /**
-     * @var string the name of the schema that this table belongs to.
+     * @var string|null the name of the schema that this table belongs to. Defaults to null, meaning no schema (or the
+     * default schema).
      */
-    public $schemaName;
+    public string|null $schemaName = null;
     /**
-     * @var string the name of this table. The schema name is not included. Use [[fullName]] to get the name with schema name prefix.
+     * @var string the name of this table. The schema name is not included. Use [[fullName]] to get the name with schema
+     * name prefix. For defa
      */
-    public $name;
+    public string $name = '';
     /**
      * @var string the full name of this table, which includes the schema name prefix, if any.
-     * Note that if the schema name is the same as the [[Schema::defaultSchema|default schema name]],
-     * the schema name will not be included.
+     * Note that if the schema name is the same as the [[Schema::defaultSchema|default schema name]], the schema name
+     * will not be included.
      */
-    public $fullName;
+    public string $fullName = '';
     /**
      * @var string[] primary keys of this table.
      */
-    public $primaryKey = [];
+    public array $primaryKey = [];
     /**
      * @var string|null sequence name for the primary key. Null if no sequence.
      */
-    public $sequenceName;
+    public string|null $sequenceName = null;
     /**
      * @var array foreign keys of this table. Each array element is of the following structure:
      *
@@ -53,45 +49,57 @@ class TableSchema extends BaseObject
      * ]
      * ```
      */
-    public $foreignKeys = [];
+    public array $foreignKeys = [];
     /**
-     * @var ColumnSchema[] column metadata of this table. Each array element is a [[ColumnSchema]] object, indexed by column names.
+     * @var ColumnSchema[] column metadata of this table. Each array element is a [[ColumnSchema]] object, indexed by
+     * column names.
      */
-    public $columns = [];
-
+    public array $columns = [];
+    /**
+     * @var string|null the name of the server that this table belongs to. Defaults to null, meaning no server (or the
+     * current server).
+     */
+    public string|null $serverName = null;
 
     /**
      * Gets the named column metadata.
      * This is a convenient method for retrieving a named column even if it does not exist.
-     * @param string $name column name
+     *
+     * @param string $name column name.
+     *
      * @return ColumnSchema|null metadata of the named column. Null if the named column does not exist.
      */
-    public function getColumn($name)
+    public function getColumn(string $name): ColumnSchema|null
     {
         return isset($this->columns[$name]) ? $this->columns[$name] : null;
     }
 
     /**
      * Returns the names of all columns in this table.
-     * @return array list of column names
+     *
+     * @return array list of column names.
      */
-    public function getColumnNames()
+    public function getColumnNames(): array
     {
         return array_keys($this->columns);
     }
 
     /**
      * Manually specifies the primary key for this table.
-     * @param string|array $keys the primary key (can be composite)
+     *
+     * @param string|array $keys the primary key (can be composite).
+     *
      * @throws InvalidArgumentException if the specified key cannot be found in the table.
      */
-    public function fixPrimaryKey($keys)
+    public function fixPrimaryKey(string|array $keys): void
     {
         $keys = (array) $keys;
         $this->primaryKey = $keys;
+
         foreach ($this->columns as $column) {
             $column->isPrimaryKey = false;
         }
+
         foreach ($keys as $key) {
             if (isset($this->columns[$key])) {
                 $this->columns[$key]->isPrimaryKey = true;

--- a/src/db/mssql/Schema.php
+++ b/src/db/mssql/Schema.php
@@ -1,9 +1,6 @@
 <?php
-/**
- * @link https://www.yiiframework.com/
- * @copyright Copyright (c) 2008 Yii Software LLC
- * @license https://www.yiiframework.com/license/
- */
+
+declare(strict_types=1);
 
 namespace yii\db\mssql;
 
@@ -18,11 +15,16 @@ use yii\db\IndexConstraint;
 use yii\db\ViewFinderTrait;
 use yii\helpers\ArrayHelper;
 
+use function array_reverse;
+use function explode;
+use function implode;
+use function is_array;
+use function preg_match;
+use function str_replace;
+use function stripos;
+
 /**
  * Schema is the class for retrieving metadata from MS SQL Server databases (version 2008 and above).
- *
- * @author Timur Ruziev <resurtm@gmail.com>
- * @since 2.0
  */
 class Schema extends \yii\db\Schema implements ConstraintFinderInterface
 {
@@ -93,41 +95,24 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected array|string $columnQuoteCharacter = ['[', ']'];
 
-
-    /**
-     * Resolves the table name and schema name (if any).
-     * @param string $name the table name
-     * @return TableSchema resolved table, schema, etc. names.
-     */
-    protected function resolveTableName($name)
+    protected function resolveTableName(string $name): TableSchema
     {
-        $resolvedName = new TableSchema();
-        $parts = $this->getTableNameParts($name);
-        $partCount = count($parts);
-        if ($partCount === 4) {
-            // server name, catalog name, schema name and table name passed
-            $resolvedName->catalogName = $parts[1];
-            $resolvedName->schemaName = $parts[2];
-            $resolvedName->name = $parts[3];
-            $resolvedName->fullName = $resolvedName->catalogName . '.' . $resolvedName->schemaName . '.' . $resolvedName->name;
-        } elseif ($partCount === 3) {
-            // catalog name, schema name and table name passed
-            $resolvedName->catalogName = $parts[0];
-            $resolvedName->schemaName = $parts[1];
-            $resolvedName->name = $parts[2];
-            $resolvedName->fullName = $resolvedName->catalogName . '.' . $resolvedName->schemaName . '.' . $resolvedName->name;
-        } elseif ($partCount === 2) {
-            // only schema name and table name passed
-            $resolvedName->schemaName = $parts[0];
-            $resolvedName->name = $parts[1];
-            $resolvedName->fullName = ($resolvedName->schemaName !== $this->defaultSchema ? $resolvedName->schemaName . '.' : '') . $resolvedName->name;
+        $tableSchema = new TableSchema();
+
+        $parts = array_reverse($this->db->getQuoter()->getTableNameParts($name));
+
+        $tableSchema->name = $parts[0] ?? '';
+        $tableSchema->schemaName = $parts[1] ?? $this->defaultSchema;
+        $tableSchema->catalogName = $parts[2] ?? null;
+        $tableSchema->serverName = $parts[3] ?? null;
+
+        if ($tableSchema->catalogName === null && $tableSchema->schemaName === $this->defaultSchema) {
+            $tableSchema->fullName = $parts[0];
         } else {
-            // only table name passed
-            $resolvedName->schemaName = $this->defaultSchema;
-            $resolvedName->fullName = $resolvedName->name = $parts[0];
+            $tableSchema->fullName = implode('.', array_reverse($parts));
         }
 
-        return $resolvedName;
+        return $tableSchema;
     }
 
     /**
@@ -187,14 +172,15 @@ SQL;
     /**
      * {@inheritdoc}
      */
-    protected function loadTableSchema($name)
+    protected function loadTableSchema(string $table): TableSchema|null
     {
-        $table = new TableSchema();
-        $this->resolveTableNames($table, $name);
-        $this->findPrimaryKeys($table);
-        if ($this->findColumns($table)) {
-            $this->findForeignKeys($table);
-            return $table;
+        $tableSchema = $this->resolveTableName($table);
+
+        if ($this->findColumns($tableSchema)) {
+            $this->findPrimaryKeys($tableSchema);
+            $this->findForeignKeys($tableSchema);
+
+            return $tableSchema;
         }
 
         return null;
@@ -333,39 +319,6 @@ SQL;
     public function createQueryBuilder()
     {
         return Yii::createObject(QueryBuilder::className(), [$this->db]);
-    }
-
-    /**
-     * Resolves the table name and schema name (if any).
-     * @param TableSchema $table the table metadata object
-     * @param string $name the table name
-     */
-    protected function resolveTableNames($table, $name)
-    {
-        $parts = $this->getTableNameParts($name);
-        $partCount = count($parts);
-        if ($partCount === 4) {
-            // server name, catalog name, schema name and table name passed
-            $table->catalogName = $parts[1];
-            $table->schemaName = $parts[2];
-            $table->name = $parts[3];
-            $table->fullName = $table->catalogName . '.' . $table->schemaName . '.' . $table->name;
-        } elseif ($partCount === 3) {
-            // catalog name, schema name and table name passed
-            $table->catalogName = $parts[0];
-            $table->schemaName = $parts[1];
-            $table->name = $parts[2];
-            $table->fullName = $table->catalogName . '.' . $table->schemaName . '.' . $table->name;
-        } elseif ($partCount === 2) {
-            // only schema name and table name passed
-            $table->schemaName = $parts[0];
-            $table->name = $parts[1];
-            $table->fullName = $table->schemaName !== $this->defaultSchema ? $table->schemaName . '.' . $table->name : $table->name;
-        } else {
-            // only table name passed
-            $table->schemaName = $this->defaultSchema;
-            $table->fullName = $table->name = $parts[0];
-        }
     }
 
     /**

--- a/src/db/mssql/Schema.php
+++ b/src/db/mssql/Schema.php
@@ -176,8 +176,9 @@ SQL;
     {
         $tableSchema = $this->resolveTableName($table);
 
+        $this->findPrimaryKeys($tableSchema);
+
         if ($this->findColumns($tableSchema)) {
-            $this->findPrimaryKeys($tableSchema);
             $this->findForeignKeys($tableSchema);
 
             return $tableSchema;

--- a/src/db/sqlite/Schema.php
+++ b/src/db/sqlite/Schema.php
@@ -1,9 +1,6 @@
 <?php
-/**
- * @link https://www.yiiframework.com/
- * @copyright Copyright (c) 2008 Yii Software LLC
- * @license https://www.yiiframework.com/license/
- */
+
+declare(strict_types=1);
 
 namespace yii\db\sqlite;
 
@@ -22,14 +19,18 @@ use yii\db\TableSchema;
 use yii\db\Transaction;
 use yii\helpers\ArrayHelper;
 
+use function explode;
+use function preg_match;
+use function strtolower;
+use function strncmp;
+use function strpos;
+use function trim;
+
 /**
  * Schema is the class for retrieving metadata from a SQLite (2/3) database.
  *
- * @property-write string $transactionIsolationLevel The transaction isolation level to use for this
- * transaction. This can be either [[Transaction::READ_UNCOMMITTED]] or [[Transaction::SERIALIZABLE]].
- *
- * @author Qiang Xue <qiang.xue@gmail.com>
- * @since 2.0
+ * @property-write string $transactionIsolationLevel The transaction isolation level to use for this transaction.
+ * This can be either [[Transaction::READ_UNCOMMITTED]] or [[Transaction::SERIALIZABLE]].
  */
 class Schema extends \yii\db\Schema implements ConstraintFinderInterface
 {
@@ -78,7 +79,6 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
      */
     protected array|string $columnQuoteCharacter = '`';
 
-
     /**
      * {@inheritdoc}
      */
@@ -91,15 +91,16 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
     /**
      * {@inheritdoc}
      */
-    protected function loadTableSchema($name)
+    protected function loadTableSchema(string $name): TableSchema|null
     {
-        $table = new TableSchema();
-        $table->name = $name;
-        $table->fullName = $name;
+        $tableSchema = new TableSchema();
 
-        if ($this->findColumns($table)) {
-            $this->findConstraints($table);
-            return $table;
+        $tableSchema->name = $name;
+        $tableSchema->fullName = $name;
+
+        if ($this->findColumns($tableSchema)) {
+            $this->findConstraints($tableSchema);
+            return $tableSchema;
         }
 
         return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
