### PR TITLE
Refactor `AbstractConnection::class` test case for `hasTable()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Yii Core version 2 Change Log
 - Enh #86: Remove unnecesary `resolveTableNames()` and refactor `resolveTableName()` in `Schema::class` in `MSSQL`, `MYSQL`, `OCI`, `PGSQL` (@terabytesoftw)
 - Enh #87: Refactor `TableSchema::class` in `MSSQL` (@terabytesoftw)
 - Enh #88: Implement `hasTable()` method in `Connection::class` (@terabytesoftw)
+- Enh #89: Refactor `AbstractConnection::class` test case for `hasTable()` method (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/tests/framework/db/connection/AbstractConnection.php
+++ b/tests/framework/db/connection/AbstractConnection.php
@@ -22,7 +22,12 @@ abstract class AbstractConnection extends \yiiunit\TestCase
     public function testHasTable(): void
     {
         $tableName = 'T_table';
-        $this->assertFalse($this->db->hasTable($tableName));
+
+        if ($this->db->hasTable($tableName)) {
+            $result = $this->db->createCommand()->dropTable($tableName)->execute();
+
+            $this->assertSame(0, $result);
+        }
 
         $result = $this->db->createCommand()->createTable(
             $tableName,
@@ -33,11 +38,13 @@ abstract class AbstractConnection extends \yiiunit\TestCase
         )->execute();
 
         $this->assertSame(0, $result);
-
         $this->assertTrue($this->db->hasTable($tableName));
+        $this->assertNotNull($this->db->getTableSchema($tableName));
 
         $result = $this->db->createCommand()->dropTable($tableName)->execute();
 
         $this->assertSame(0, $result);
+        $this->assertFalse($this->db->hasTable($tableName));
+        $this->assertNull($this->db->getTableSchema($tableName));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
