### PR TITLE
Refactor `findColums()` in  `MSSQL` `Schema::class`, add support for `size` and `precision` for `float` and numeric data type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Yii Core version 2 Change Log
 - Enh #87: Refactor `TableSchema::class` in `MSSQL` (@terabytesoftw)
 - Enh #88: Implement `hasTable()` method in `Connection::class` (@terabytesoftw)
 - Enh #89: Refactor `AbstractConnection::class` test case for `hasTable()` method (@terabytesoftw)
+- Enh #90: Refactor `findColums()` in  `MSSQL` `Schema::class`, add support for `size` and `precision` for `float` and numeric data type (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/mssql/Schema.php
+++ b/src/db/mssql/Schema.php
@@ -461,6 +461,10 @@ SQL;
                 }
             }
 
+            if ($column->isPrimaryKey && $column->autoIncrement) {
+                $table->sequenceName = '';
+            }
+
             $table->columns[$column->name] = $column;
         }
 

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -111,6 +111,7 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
     public function getExpectedColumns()
     {
         $columns = parent::getExpectedColumns();
+
         unset($columns['enum_col']);
         unset($columns['ts_default']);
         unset($columns['bit_col']);
@@ -120,17 +121,15 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $columns['int_col2']['dbType'] = 'int';
         $columns['tinyint_col']['dbType'] = 'tinyint';
         $columns['smallint_col']['dbType'] = 'smallint';
-        $columns['float_col']['dbType'] = 'decimal';
+        $columns['float_col']['dbType'] = 'decimal(4,3)';
         $columns['float_col']['phpType'] = 'string';
         $columns['float_col']['type'] = 'decimal';
-        $columns['float_col']['scale'] = null;
         $columns['float_col2']['dbType'] = 'float';
         $columns['float_col2']['phpType'] = 'double';
         $columns['float_col2']['type'] = 'float';
-        $columns['float_col2']['scale'] = null;
         $columns['blob_col']['dbType'] = 'varbinary';
-        $columns['numeric_col']['dbType'] = 'decimal';
-        $columns['numeric_col']['scale'] = null;
+        $columns['numeric_col']['dbType'] = 'decimal(5,2)';
+        $columns['numeric_col']['scale'] = 2;
         $columns['time']['dbType'] = 'datetime';
         $columns['time']['type'] = 'datetime';
         $columns['bool_col']['dbType'] = 'tinyint';
@@ -141,13 +140,13 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         });
 
         array_walk($columns, static function (&$item, $name) {
-            if (!in_array($name, ['char_col', 'char_col2', 'char_col3'])) {
+            if (!in_array($name, ['char_col', 'char_col2', 'char_col3', 'float_col', 'numeric_col'])) {
                 $item['size'] = null;
             }
         });
 
         array_walk($columns, static function (&$item, $name) {
-            if (!in_array($name, ['char_col', 'char_col2', 'char_col3'])) {
+            if (!in_array($name, ['char_col', 'char_col2', 'char_col3', 'float_col', 'numeric_col'])) {
                 $item['precision'] = null;
             }
         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
