### PR TITLE
Add enum `PHPType::class` and  refactor `getColumnPhpType()` method in `Schema::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Yii Core version 2 Change Log
 - Enh #88: Implement `hasTable()` method in `Connection::class` (@terabytesoftw)
 - Enh #89: Refactor `AbstractConnection::class` test case for `hasTable()` method (@terabytesoftw)
 - Enh #90: Refactor `findColums()` in  `MSSQL` `Schema::class`, add support for `size` and `precision` for `float` and numeric data type (@terabytesoftw)
+- Enh #91: Add enum `PHPType::class` and  refactor `getColumnPhpType()` method in `Schema::class` (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/PHPType.php
+++ b/src/db/PHPType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii\db;
+
+enum PHPType: string
+{
+    case INTEGER = 'integer';
+    case STRING = 'string';
+    case BOOLEAN = 'boolean';
+    case DOUBLE = 'double';
+    case RESOURCE = 'resource';
+    case ARRAY = 'array';
+    case NULL = 'NULL';
+}

--- a/src/db/Schema.php
+++ b/src/db/Schema.php
@@ -512,34 +512,24 @@ abstract class Schema extends BaseObject
 
     /**
      * Extracts the PHP type from abstract DB type.
-     * @param ColumnSchema $column the column schema information
-     * @return string PHP type name
+     *
+     * @param ColumnSchema $column the column schema information.
+     *
+     * @return string PHP type name.
      */
-    protected function getColumnPhpType($column)
+    protected function getColumnPhpType(ColumnSchema $column): string
     {
-        static $typeMap = [
-            // abstract type => php type
-            self::TYPE_TINYINT => 'integer',
-            self::TYPE_SMALLINT => 'integer',
-            self::TYPE_INTEGER => 'integer',
-            self::TYPE_BIGINT => 'integer',
-            self::TYPE_BOOLEAN => 'boolean',
-            self::TYPE_FLOAT => 'double',
-            self::TYPE_DOUBLE => 'double',
-            self::TYPE_BINARY => 'resource',
-            self::TYPE_JSON => 'array',
-        ];
-        if (isset($typeMap[$column->type])) {
-            if ($column->type === 'bigint') {
-                return PHP_INT_SIZE === 8 && !$column->unsigned ? 'integer' : 'string';
-            } elseif ($column->type === 'integer') {
-                return PHP_INT_SIZE === 4 && $column->unsigned ? 'string' : 'integer';
-            }
+        $phpType = match ($column->type) {
+            self::TYPE_TINYINT, self::TYPE_SMALLINT, self::TYPE_INTEGER => PHPType::INTEGER,
+            self::TYPE_BIGINT => PHP_INT_SIZE === 8 ? PHPType::INTEGER : PHPType::STRING,
+            self::TYPE_BOOLEAN => PHPType::BOOLEAN,
+            self::TYPE_DECIMAL, self::TYPE_FLOAT, self::TYPE_DOUBLE => PHPType::DOUBLE,
+            self::TYPE_BINARY => PHPType::RESOURCE,
+            self::TYPE_JSON => PHPType::ARRAY,
+            default => PHPType::STRING,
+        };
 
-            return $typeMap[$column->type];
-        }
-
-        return 'string';
+        return $phpType->value;
     }
 
     /**

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -8,6 +8,7 @@ use Yii;
 use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
 use yii\db\CheckConstraint;
+use yii\db\ColumnSchema;
 use yii\db\Constraint;
 use yii\db\ConstraintFinderInterface;
 use yii\db\ConstraintFinderTrait;
@@ -15,6 +16,7 @@ use yii\db\Exception;
 use yii\db\Expression;
 use yii\db\ForeignKeyConstraint;
 use yii\db\IndexConstraint;
+use yii\db\PHPType;
 use yii\db\TableSchema;
 use yii\helpers\ArrayHelper;
 
@@ -651,5 +653,20 @@ SQL;
         }
 
         return $result;
+    }
+
+    protected function getColumnPhpType(ColumnSchema $column): string
+    {
+        if ($column->unsigned) {
+            if ($column->type === self::TYPE_INTEGER && PHP_INT_SIZE === 4) {
+                return PHPType::STRING->value;
+            }
+
+            if ($column->type === self::TYPE_BIGINT && PHP_INT_SIZE === 8) {
+                return PHPType::STRING->value;
+            }
+        }
+
+        return parent::getColumnPhpType($column);
     }
 }

--- a/src/db/oci/ColumnSchema.php
+++ b/src/db/oci/ColumnSchema.php
@@ -24,4 +24,13 @@ class ColumnSchema extends \yii\db\ColumnSchema
 
         return parent::dbTypecast($value);
     }
+
+    protected function typecast($value)
+    {
+        if ($this->phpType === 'string' && is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        return parent::typecast($value);
+    }
 }

--- a/tests/framework/db/SchemaTest.php
+++ b/tests/framework/db/SchemaTest.php
@@ -414,7 +414,7 @@ abstract class SchemaTest extends DatabaseTestCase
             'numeric_col' => [
                 'type' => 'decimal',
                 'dbType' => 'decimal(5,2)',
-                'phpType' => 'string',
+                'phpType' => 'double',
                 'allowNull' => true,
                 'autoIncrement' => false,
                 'enumValues' => null,

--- a/tests/framework/db/mssql/SchemaTest.php
+++ b/tests/framework/db/mssql/SchemaTest.php
@@ -122,7 +122,6 @@ class SchemaTest extends \yiiunit\framework\db\SchemaTest
         $columns['tinyint_col']['dbType'] = 'tinyint';
         $columns['smallint_col']['dbType'] = 'smallint';
         $columns['float_col']['dbType'] = 'decimal(4,3)';
-        $columns['float_col']['phpType'] = 'string';
         $columns['float_col']['type'] = 'decimal';
         $columns['float_col2']['dbType'] = 'float';
         $columns['float_col2']['phpType'] = 'double';

--- a/tests/framework/db/mssql/provider/QueryBuilderProvider.php
+++ b/tests/framework/db/mssql/provider/QueryBuilderProvider.php
@@ -107,7 +107,7 @@ final class QueryBuilderProvider extends \yiiunit\framework\db\provider\Abstract
                 <<<SQL
                 SET NOCOUNT ON;DECLARE @temporary_inserted TABLE ([order_id] int , [item_id] int );INSERT INTO {{%order_item}} ([order_id], [item_id], [quantity], [subtotal]) OUTPUT INSERTED.[order_id],INSERTED.[item_id] INTO @temporary_inserted VALUES (:qp0, :qp1, :qp2, :qp3);SELECT * FROM @temporary_inserted;
                 SQL,
-                [':qp0' => 1, ':qp1' => 1, ':qp2' => 1, ':qp3' => '1'],
+                [':qp0' => 1, ':qp1' => 1, ':qp2' => 1, ':qp3' => 1.0],
             ],
             'without primary key' => [
                 '{{%type}}',

--- a/tests/framework/db/oci/QueryBuilderTest.php
+++ b/tests/framework/db/oci/QueryBuilderTest.php
@@ -208,7 +208,7 @@ class QueryBuilderTest extends \yiiunit\framework\db\QueryBuilderTest
             "VALUES ('no columns passed') SELECT 1 FROM SYS.DUAL";
 
         $data['bool-false, bool2-null']['expected'] = 'INSERT ALL  INTO "type" ("bool_col", "bool_col2") ' .
-            "VALUES ('', NULL) SELECT 1 FROM SYS.DUAL";
+            "VALUES ('0', NULL) SELECT 1 FROM SYS.DUAL";
 
         $data[3][3] = 'INSERT ALL  INTO {{%type}} ({{%type}}.[[float_col]], [[time]]) ' .
             "VALUES (NULL, now()) SELECT 1 FROM SYS.DUAL";

--- a/tests/framework/db/pgsql/provider/QueryBuilderProvider.php
+++ b/tests/framework/db/pgsql/provider/QueryBuilderProvider.php
@@ -116,7 +116,7 @@ final class QueryBuilderProvider extends \yiiunit\framework\db\provider\Abstract
                 <<<SQL
                 INSERT INTO {{%order_item}} ("order_id", "item_id", "quantity", "subtotal") VALUES (:qp0, :qp1, :qp2, :qp3) RETURNING "order_id", "item_id"
                 SQL,
-                [':qp0' => 1, ':qp1' => 1, ':qp2' => 1, ':qp3' => '1'],
+                [':qp0' => 1, ':qp1' => 1, ':qp2' => 1, ':qp3' => 1.0],
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
