### PR TITLE
Move `getRawTableName()` to `Quoter::class`, and better arguments naming in `Quoter::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Yii Core version 2 Change Log
 - Enh #91: Add enum `PHPType::class` and  refactor `getColumnPhpType()` method in `Schema::class` (@terabytesoftw)
 - Enh #92: Refactor `batchInsert()` method in `Command::class`, and `QueryBuilder::class` (@terabytesoftw)
 - Bug #93: Use `Quoter::class` insted of specific methods in `Schema::class` for `MSSQL`, `OCI` (@terabytesoftw)
+- Enh #95: Move `getRawTableName()` to `Quoter::class`, and better arguments naming in `Quoter::class` (@terabytesoftw)
 
 
 Yii Framework 2 Change Log

--- a/src/db/Connection.php
+++ b/src/db/Connection.php
@@ -914,9 +914,20 @@ class Connection extends Component
         throw new NotSupportedException("Connection does not support reading schema information for '$driver' DBMS.");
     }
 
+    /**
+     * Returns the Quoter instance for the current database connection.
+     *
+     * If the quoter has not been initialized yet, it will create one based on the database driver and schema.
+     * The method checks the `quoterMap` to determine the configuration for the quoter. If the quoter is already
+     * initialized, it returns the existing instance.
+     *
+     * If prefix has been changed, the quoter will be re-created.
+     *
+     * @return Quoter the quoter instance configured for quoting database identifiers (table and column names).
+     */
     public function getQuoter(): Quoter
     {
-        if ($this->_quoter === null) {
+        if ($this->_quoter === null || $this->_quoter->getTablePrefix() !== $this->tablePrefix) {
             $driver = $this->getDriverName();
             $schema = $this->getSchema();
 

--- a/src/db/Schema.php
+++ b/src/db/Schema.php
@@ -435,20 +435,17 @@ abstract class Schema extends BaseObject
 
     /**
      * Returns the actual name of a given table name.
-     * This method will strip off curly brackets from the given table name
-     * and replace the percentage character '%' with [[Connection::tablePrefix]].
-     * @param string $name the table name to be converted
-     * @return string the real name of the given table name
+     *
+     * This method will strip off curly brackets from the given table name and replace the percentage character '%' with
+     * [[Connection::tablePrefix]].
+     *
+     * @param string $tableName the table name to be converted.
+     *
+     * @return string the real name of the given table name.
      */
-    public function getRawTableName($name)
+    public function getRawTableName(string $tableName): string
     {
-        if (strpos($name, '{{') !== false) {
-            $name = preg_replace('/\\{\\{(.*?)\\}\\}/', '\1', $name);
-
-            return str_replace('%', $this->db->tablePrefix, $name);
-        }
-
-        return $name;
+        return $this->db->getQuoter()->getRawTableName($tableName);
     }
 
     /**
@@ -630,10 +627,13 @@ abstract class Schema extends BaseObject
                 $cache = $schemaCache;
             }
         }
+
         $rawName = $this->getRawTableName($name);
+
         if (!isset($this->_tableMetadata[$rawName])) {
             $this->loadTableMetadataFromCache($cache, $rawName);
         }
+
         if ($refresh || !array_key_exists($type, $this->_tableMetadata[$rawName])) {
             $this->_tableMetadata[$rawName][$type] = $this->{'loadTable' . ucfirst($type)}($rawName);
             $this->saveTableMetadataToCache($cache, $rawName);

--- a/src/db/mssql/Quoter.php
+++ b/src/db/mssql/Quoter.php
@@ -13,23 +13,23 @@ use function preg_match_all;
  */
 final class Quoter extends \yii\db\Quoter
 {
-    public function getTableNameParts(string $name, bool $withColumn = false): array
+    public function getTableNameParts(string $tableName, bool $withColumn = false): array
     {
-        if (preg_match_all('/([^.\[\]]+)|\[([^\[\]]+)]/', $name, $matches)) {
+        if (preg_match_all('/([^.\[\]]+)|\[([^\[\]]+)]/', $tableName, $matches)) {
             $parts = array_slice($matches[0], -4, 4);
         } else {
-            $parts = [$name];
+            $parts = [$tableName];
         }
 
         return $this->unquoteParts($parts, $withColumn);
     }
 
-    public function quoteColumnName(string $name): string
+    public function quoteColumnName(string $columnName): string
     {
-        if (preg_match('/^\[.*]$/', $name)) {
-            return $name;
+        if (preg_match('/^\[.*]$/', $columnName)) {
+            return $columnName;
         }
 
-        return parent::quoteColumnName($name);
+        return parent::quoteColumnName($columnName);
     }
 }

--- a/src/db/oci/Quoter.php
+++ b/src/db/oci/Quoter.php
@@ -11,8 +11,8 @@ use function str_contains;
  */
 final class Quoter extends \yii\db\Quoter
 {
-    public function quoteSimpleTableName(string $name): string
+    public function quoteSimpleTableName(string $tableName): string
     {
-        return str_contains($name, '"') ? $name : '"' . $name . '"';
+        return str_contains($tableName, '"') ? $tableName : '"' . $tableName . '"';
     }
 }

--- a/src/db/sqlite/Quoter.php
+++ b/src/db/sqlite/Quoter.php
@@ -12,9 +12,9 @@ use function explode;
  */
 final class Quoter extends \yii\db\Quoter
 {
-    public function getTableNameParts(string $name, bool $withColumn = false): array
+    public function getTableNameParts(string $tableName, bool $withColumn = false): array
     {
-        $parts = array_slice(explode('.', $name), -2, 2);
+        $parts = array_slice(explode('.', $tableName), -2, 2);
 
         return $this->unquoteParts($parts, $withColumn);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
