### PR TITLE
Move `extractAlias()` method to `Quoter::class`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,16 @@ Yii Core version 2 Change Log
 - Bug #72: Add type hint in method in BuildTest.php for `MSSQL` (@terabytesoftw)
 - Bug #75: Refactor `prepareInsertValues()` method in `QueryBuilder::class` to accept `TableSchema` object (@terabytesoftw)
 - Bug #77: Add support for test `Oci` 18, 21 (@terabytesoftw)
-- Bug #78: Fix test case for `getSchemaNames()` method in `SchemaTest::class` in `Oci` (@terabytesoftw)
+- Bug #78: Fix test case for `getSchemaNames()` method in `SchemaTest::class` in `Oracle` (@terabytesoftw)
 - Enh #84: Remove `Oracle-11c` service image versions in build workflow (@terabytesoftw)
-- Enh #86: Remove unnecesary `resolveTableNames()` and refactor `resolveTableName()` in `Schema::class` in `MSSQL`, `MySQL`, `Oci`, `PostgreSQL` (@terabytesoftw)
+- Enh #86: Remove unnecesary `resolveTableNames()` and refactor `resolveTableName()` in `Schema::class` in `MSSQL`, `MySQL`, `Oracle`, `PostgreSQL` (@terabytesoftw)
 - Enh #87: Refactor `TableSchema::class` in `MSSQL` (@terabytesoftw)
 - Enh #88: Implement `hasTable()` method in `Connection::class` (@terabytesoftw)
 - Enh #89: Refactor `AbstractConnection::class` test case for `hasTable()` method (@terabytesoftw)
 - Enh #90: Refactor `findColums()` in  `MSSQL` `Schema::class`, add support for `size` and `precision` for `float` and numeric data type (@terabytesoftw)
 - Enh #91: Add enum `PHPType::class` and  refactor `getColumnPhpType()` method in `Schema::class` (@terabytesoftw)
 - Enh #92: Refactor `batchInsert()` method in `Command::class`, and `QueryBuilder::class` (@terabytesoftw)
-- Bug #93: Use `Quoter::class` insted of specific methods in `Schema::class` for `MSSQL`, `Oci` (@terabytesoftw)
+- Bug #93: Use `Quoter::class` insted of specific methods in `Schema::class` for `MSSQL`, `Oracle` (@terabytesoftw)
 - Enh #95: Move `getRawTableName()` to `Quoter::class`, and better arguments naming in `Quoter::class` (@terabytesoftw)
 - Bug #96: Remove unnecesary `testUpsert()`, move to separate directory `command` and `querybuilder` (@terabytesoftw)
 - Enh #97: Add `getNextAutoIncrementValue()` method in `Schema::class` (@terabytesoftw)
@@ -44,6 +44,7 @@ Yii Core version 2 Change Log
 - Bug #103: Remove `server:2017-latest` in `github actions` and add in `appveyor.yml` (@terabytesoftw)
 - Bug #104: Remove `insert()` method from `Schema::class` (@terabytesoftw)
 - Bug #105: Removed the `sequenceName` property from the `TableSchema::class` and added it to the `ColumnSchema::class` (@terabytesoftw)
+- Enh #106: Move `extractAlias()` method to `Quoter::class` (@terabytesoftw)
 
 Yii Framework 2 Change Log
 ==========================

--- a/src/db/QueryBuilder.php
+++ b/src/db/QueryBuilder.php
@@ -1686,18 +1686,15 @@ class QueryBuilder extends \yii\base\BaseObject
     }
 
     /**
-     * Extracts table alias if there is one or returns false
-     * @param $table
-     * @return bool|array
-     * @since 2.0.24
+     * Extracts table alias.
+     *
+     * @param string $tableName The table name.
+     *
+     * @return bool|array The table name and alias. False if no alias is found.
      */
-    protected function extractAlias($table)
+    public function extractAlias(string $tableName): bool|array
     {
-        if (preg_match('/^(.*?)(?i:\s+as|)\s+([^ ]+)$/', $table, $matches)) {
-            return $matches;
-        }
-
-        return false;
+        return $this->db->getQuoter()->extractAlias($tableName);
     }
 
     /**

--- a/src/db/Quoter.php
+++ b/src/db/Quoter.php
@@ -37,6 +37,39 @@ class Quoter
     }
 
     /**
+     * Ensures name of the column is wrapped with `[[ and ]]`.
+     *
+     * @param string $columnName the name to quote.
+     *
+     * @return string the quoted name.
+     */
+    public function ensureColumnName(string $columnName): string
+    {
+        if (strrpos($columnName, '.') !== false) {
+            $parts = explode('.', $columnName);
+            $columnName = $parts[count($parts) - 1];
+        }
+
+        return preg_replace('|^\[\[([_\w\-. ]+)\]\]$|', '\1', $columnName);
+    }
+
+    /**
+     * Extracts table alias.
+     *
+     * @param string $tableName The table name.
+     *
+     * @return bool|array The table name and alias. False if no alias is found.
+     */
+    public function extractAlias(string $tableName): array|false
+    {
+        if (preg_match('/^(.*?)(?i:\s+as|)\s+([^ ]+)$/', $tableName, $matches)) {
+            return $matches;
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the table prefix to be used for table names.
      *
      * @return string the table prefix to be used for table names.
@@ -81,23 +114,6 @@ class Quoter
             },
             $tableName
         );
-    }
-
-    /**
-     * Ensures name of the column is wrapped with `[[ and ]]`.
-     *
-     * @param string $columnName the name to quote.
-     *
-     * @return string the quoted name.
-     */
-    public function ensureColumnName(string $columnName): string
-    {
-        if (strrpos($columnName, '.') !== false) {
-            $parts = explode('.', $columnName);
-            $columnName = $parts[count($parts) - 1];
-        }
-
-        return preg_replace('|^\[\[([_\w\-. ]+)\]\]$|', '\1', $columnName);
     }
 
     /**

--- a/src/db/mssql/QueryBuilder.php
+++ b/src/db/mssql/QueryBuilder.php
@@ -561,18 +561,6 @@ class QueryBuilder extends \yii\db\QueryBuilder
     }
 
     /**
-     * {@inheritdoc}
-     */
-    protected function extractAlias($table)
-    {
-        if (preg_match('/^\[.*\]$/', $table)) {
-            return false;
-        }
-
-        return parent::extractAlias($table);
-    }
-
-    /**
      * Builds a SQL statement for dropping constraints for column of table.
      *
      * @param string $table the table whose constraint is to be dropped. The name will be properly quoted by the method.

--- a/src/db/mssql/Quoter.php
+++ b/src/db/mssql/Quoter.php
@@ -13,6 +13,21 @@ use function preg_match_all;
  */
 final class Quoter extends \yii\db\Quoter
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function extractAlias(string $tableName): array|false
+    {
+        if (preg_match('/^\[.*\]$/', $tableName)) {
+            return false;
+        }
+
+        return parent::extractAlias($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getTableNameParts(string $tableName, bool $withColumn = false): array
     {
         if (preg_match_all('/([^.\[\]]+)|\[([^\[\]]+)]/', $tableName, $matches)) {
@@ -24,6 +39,9 @@ final class Quoter extends \yii\db\Quoter
         return $this->unquoteParts($parts, $withColumn);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function quoteColumnName(string $columnName): string
     {
         if (preg_match('/^\[.*]$/', $columnName)) {

--- a/src/db/mysql/Quoter.php
+++ b/src/db/mysql/Quoter.php
@@ -15,6 +15,9 @@ use function str_replace;
  */
 final class Quoter extends \yii\db\Quoter
 {
+    /**
+     * {@inheritdoc}
+     */
     public function quoteValue(mixed $value): mixed
     {
         if (!is_string($value)) {

--- a/src/db/oci/Quoter.php
+++ b/src/db/oci/Quoter.php
@@ -11,6 +11,9 @@ use function str_contains;
  */
 final class Quoter extends \yii\db\Quoter
 {
+    /**
+     * {@inheritdoc}
+     */
     public function quoteSimpleTableName(string $tableName): string
     {
         return str_contains($tableName, '"') ? $tableName : '"' . $tableName . '"';

--- a/src/db/sqlite/Quoter.php
+++ b/src/db/sqlite/Quoter.php
@@ -12,6 +12,9 @@ use function explode;
  */
 final class Quoter extends \yii\db\Quoter
 {
+    /**
+     * {@inheritdoc}
+     */
     public function getTableNameParts(string $tableName, bool $withColumn = false): array
     {
         $parts = array_slice(explode('.', $tableName), -2, 2);

--- a/tests/framework/db/mssql/schema/QuoterTest.php
+++ b/tests/framework/db/mssql/schema/QuoterTest.php
@@ -29,6 +29,13 @@ final class QuoterTest extends \yiiunit\framework\db\schema\AbstractQuoter
         parent::testEnsureColumnName($columnName, $expected);
     }
 
+    public function testExtractAliasWithBrackets(): void
+    {
+        $tableName = '[dbo].[users]';
+
+        $this->assertFalse($this->db->getQuoter()->extractAlias($tableName));
+    }
+
     /**
      * @dataProvider \yiiunit\framework\db\mssql\provider\QuoterProvider::tableNameParts
      */

--- a/tests/framework/db/schema/AbstractQuoter.php
+++ b/tests/framework/db/schema/AbstractQuoter.php
@@ -26,6 +26,36 @@ abstract class AbstractQuoter extends TestCase
         $this->assertSame($expected, $this->db->getQuoter()->ensureColumnName($columnName));
     }
 
+    public function testExtractAliasWithAlias(): void
+    {
+        $tableName = 'users u';
+        $expected = ['users u', 'users', 'u'];
+
+        $this->assertSame($expected, $this->db->getQuoter()->extractAlias($tableName));
+    }
+
+    public function testExtractAliasWithoutAlias(): void
+    {
+        $tableName = 'users';
+
+        $this->assertFalse($this->db->getQuoter()->extractAlias($tableName));
+    }
+
+    public function testExtractAliasWithASKeyword(): void
+    {
+        $tableName = 'users AS u';
+        $expected = ['users AS u', 'users', 'u'];
+
+        $this->assertSame($expected, $this->db->getQuoter()->extractAlias($tableName));
+    }
+
+    public function testExtractAliasNoAliasFound(): void
+    {
+        $tableName = 'invalid_table_name';
+
+        $this->assertFalse($this->db->getQuoter()->extractAlias($tableName));
+    }
+
     public function testGetTableNameParts(string $tableName, string ...$expected): void
     {
         $this->assertSame($expected, array_reverse($this->db->getQuoter()->getTableNameParts($tableName)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/php-forge/yii2-core/issues/57
